### PR TITLE
http2: don't reuse Transport conns after seeing stream protocol errors

### DIFF
--- a/http2/errors.go
+++ b/http2/errors.go
@@ -67,6 +67,11 @@ type StreamError struct {
 	Cause    error // optional additional detail
 }
 
+// errFromPeer is a sentinel error value for StreamError.Cause to
+// indicate that the StreamError was sent from the peer over the wire
+// and wasn't locally generated in the Transport.
+var errFromPeer = errors.New("received from peer")
+
 func streamError(id uint32, code ErrCode) StreamError {
 	return StreamError{StreamID: id, Code: code}
 }


### PR DESCRIPTION
Updates tailscale/corp#2363
Updates golang/go#47635
Updates golang/go#42777